### PR TITLE
Change `message` and `author` back to Objects (4.0.0)

### DIFF
--- a/discord/discordMessage.html
+++ b/discord/discordMessage.html
@@ -27,7 +27,8 @@
 <script type="text/x-red" data-help-name="discordMessage">
     <p>Triggers whenever a message was received on Discord.</p>
     <p><code>msg.payload</code> will be set to the textual content of the message.</p>
-    <p><code>msg.channel</code> will be set to the <a href="https://discord.js.org/#/docs/main/stable/class/Channel" target="_blank">channel</a>ID of the channel the message was received on.</p>
-    <p><code>msg.author</code> will be set to the <a href="https://discord.js.org/#/docs/main/stable/class/User" target="_blank">user</a>ID of the user that sent the message.</p>
+    <p><code>msg.channel</code> will be set to an Object containing info on the <a href="https://discord.js.org/#/docs/main/stable/class/Channel" target="_blank">channel</a> the message was received from (does not contain any discord.js functions)</p>
+    <p><code>msg.author</code> will be set to an Object containing info on the <a href="https://discord.js.org/#/docs/main/stable/class/User" target="_blank">user</a> that sent the message (does not contain any discord.js functions)</p>
+    <p><code>msg.data</code> <em>may</em> be set to an Object containing info on the <a href="https://discord.js.org/#/docs/main/stable/class/Message" target="_blank">message</a> that was received, but again without any of the discord.js functions.</p>
     <p>To reply to a message without a @mention, use the <code>discordSendMessage</code> node.</p>
 </script>

--- a/discord/discordMessage.js
+++ b/discord/discordMessage.js
@@ -1,3 +1,4 @@
+const Flatted = require('flatted/cjs');
 module.exports = function(RED) {
     var i = 0;
     var discordBotManager = require('./lib/discordBotManager.js');
@@ -19,8 +20,13 @@ module.exports = function(RED) {
                     var msgid = RED.util.generateId();
                     var msg = {_msgid:msgid}
                     msg.payload = message.content;
-                    msg.channel = message.channel.id;
-                    msg.author = message.author.id;
+                    msg.channel = Flatted.parse(Flatted.stringify(message.channel));
+                    msg.author = Flatted.parse(Flatted.stringify(message.author));
+                    try {
+                        msg.data = Flatted.parse(Flatted.stringify(message));
+                    } catch (e) {
+                        node.warn("Could not set `msg.data`: JSON serialization failed");
+                    }
                     node.send(msg);
                 }
             });

--- a/discord/discordSendMessage.html
+++ b/discord/discordSendMessage.html
@@ -31,5 +31,5 @@
     </div>
 </script>
 <script type="text/x-red" data-help-name="discordSendMessage">
-    <p>Sends msg.payload on Discord channel with id <code>msg.channel</code></p>
+    <p>Sends msg.payload on Discord channel with id <code>msg.channel.id</code> or <code>msg.channel</code></p>
 </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-discord",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Node-RED node for interacting with Discord",
   "main": "discord/discord.js",
   "scripts": {
@@ -9,7 +9,8 @@
   "author": "Joris van de Donk <jorisvddonk@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "discord.js": "^11.0.0"
+    "discord.js": "^11.0.0",
+    "flatted": "^2.0.0"
   },
   "bugs": {
     "url": "https://github.com/jorisvddonk/node-red-contrib-discord/issues"


### PR DESCRIPTION
This uses flatted (https://github.com/WebReflection/flatted) instead of JSON, as it handles circular structures without throwing a TypeError.
Due to this breaking previous usage, the version has been bumped to 4.0.0
Fixes jorisvddonk#5 and effectively includes jorisvddonk#9 and jorisvddonk#11